### PR TITLE
Fix - About Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ This is the list of corrections asked.
 </details>
 
 <details>
+  <summary>About Page</summary>
+
+  - [ ] Space between Eduardo's photo and Text below
+  - [X] Text below Eduardo's Photo should be bigger and its area should be wider
+  - [X] Hover over text "I'm available..." should activate the underscored action and the pointer should change and on click should open a new page with the following URL www.eddbeatmusic.com/contact
+  - [X] The area where the images appear should be bigger
+
+</details>
+
+<details>
   <summary>Contact Page</summary>
 
   - [ ] On the inspired with my work section the Long disc should be align with the text on the right

--- a/components/elements/ImageOnHover/ImageOnHover.js
+++ b/components/elements/ImageOnHover/ImageOnHover.js
@@ -70,9 +70,24 @@ const ImageOnHover = ({ id, images = [], text, size, ...props }) => {
           setOpacity(0);
         }}
         onMouseEnter={() => setOpacity(1)}
-        sx={{ zIndex: '50', mixBlendMode: 'difference', cursor: 'default' }}
+        sx={{ 
+          zIndex: '50',
+          mixBlendMode: 'difference',
+          cursor: 'default',
+          position: 'relative',
+        }}
         className="bound"
       >
+        <div 
+          style={{
+            position: 'absolute',
+            top: '-50px',
+            left: '-50px',
+            right: '-50px',
+            bottom: '-50px',
+            pointerEvents: 'auto',
+          }}
+        />
         {props.children}
       </Box>
       <Box className="cursor-move" style={inStyle}></Box>

--- a/pages/about/About.js
+++ b/pages/about/About.js
@@ -27,9 +27,9 @@ const About = () => {
         <Typography
           variant="subtitle1"
           color="white"
-          marginX="22vw"
           textAlign="center"
-          marginBottom="5rem"
+          marginBottom="10rem"
+          sx={{marginX: {md: "10vw", xs: "8vw"}}}
         >
           My goal is always to make outstanding sounds and original soundtracks
           that will help amplify the narrative and experience of your project.
@@ -75,14 +75,17 @@ const About = () => {
               </Box>
             </Box>
             <Box width="35rem">
-              <Typography
+              <Link
                 variant="subtitle4"
+                underline="none"
                 color="white"
                 fontStyle="italic"
-                style={{ textDecoration: 'underline' }}
+                className='footer-social'
+                href={"https://www.eddbeatmusic.com/contact"}
+                target="_blank"
               >
                 I’m Available for freelance work, collaborations and workshops.
-              </Typography>
+              </Link>
             </Box>
             <Box width="19rem">
               <Typography variant="h3" color="white" lineHeight={1}>
@@ -92,21 +95,22 @@ const About = () => {
             <Box>
               <Stack spacing={2}>
                 {FooterSocial.map((item, i) => (
-                  <Link
-                    key={i}
-                    variant="subtitle4"
-                    underline="none"
-                    href={item.href}
-                    target="_blank"
-                  >
-                    <Box
-                      component="span"
-                      className="footer-social"
-                      sx={{ marginBottom: '0.07em', paddingRight: '7px' }}
-                    >
-                      {item.title}
-                    </Box>
-                  </Link>
+                  <Box key={i} display="block">
+                    <Link
+                      variant="subtitle4"
+                      underline="none"
+                      href={item.href}
+                      target="_blank"
+                      >
+                      <Box
+                        component="span"
+                        className="footer-social"
+                        sx={{ marginBottom: '0.07em', paddingRight: '7px' }}
+                        >
+                        {item.title}
+                      </Box>
+                    </Link>
+                  </Box>
                 ))}
               </Stack>
             </Box>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -280,7 +280,7 @@ a {
 }
 
 .footer-social {
-  border-bottom: 0.08em solid #fff;
+  border-bottom: 0.05em solid #fff;
   background-image: linear-gradient(#fff 0 0);
   background-size: 200% 0.07em; /* .08em is our fixed height, use what you want  */
   background-position: 200% 104%;


### PR DESCRIPTION
Text below Eduardo's Photo is bigger and wider
Text I'm available has the transition required and when clicked it opens a new tab
the area of the hover on achievements and experience is bigger now